### PR TITLE
Desativação de Características #4

### DIFF
--- a/src/Controllers/FeatureController.js
+++ b/src/Controllers/FeatureController.js
@@ -3,7 +3,9 @@ const Feature = require('../Models/FeatureSchema');
 const { validateFeatures } = require('../Utils/validate');
 
 const getFeaturesList = async (req, res) => {
-  const features = await Feature.find();
+  const features = await Feature.find({
+    active: true
+  });
 
   return res.json(features);
 };
@@ -11,7 +13,7 @@ const getFeaturesList = async (req, res) => {
 const getFeaturesByID = async (req, res) => {
   const { featuresList } = req.body;
   try {
-    const features = await Feature.find({ _id: { $in: featuresList } });
+    const features = await Feature.find({ _id: { $in: featuresList }, active: true });
     return res.status(200).json(features);
   } catch (err) {
     return res.status(400).json({ message: 'Invalid ID' });
@@ -76,6 +78,20 @@ const deleteFeature = async (req, res) => {
   }
 };
 
+const desactiveFeature = async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const updateResponse = await Feature.findOneAndUpdate({ _id: id }, {
+      active: false,
+      updatedAt: moment.utc(moment.tz('America/Sao_Paulo').format('YYYY-MM-DDTHH:mm:ss')).toDate(),
+    }, { new: true }, (feature) => feature);
+    return res.status(200).json(updateResponse);
+  } catch (error) {
+    return res.status(400).json({ message: 'Invalid ID' });
+  }
+}
+
 module.exports = {
-  getFeaturesList, getFeaturesByID, createFeature, updateFeature, deleteFeature,
+  getFeaturesList, getFeaturesByID, createFeature, updateFeature, deleteFeature, desactiveFeature
 };

--- a/src/Models/FeatureSchema.js
+++ b/src/Models/FeatureSchema.js
@@ -21,6 +21,11 @@ const featureSchema = new mongoose.Schema({
     type: Date,
     require: true,
   },
+  active: {
+    type: Boolean,
+    require: true,
+    default: true
+  }
 });
 
 module.exports = mongoose.model('Feature', featureSchema);

--- a/src/routes.js
+++ b/src/routes.js
@@ -29,6 +29,7 @@ routes.post(
 routes.get('/features/', verifyJWT, FeatureController.getFeaturesList);
 routes.post('/featuresbyid/', verifyJWT, FeatureController.getFeaturesByID);
 routes.post('/feature/create', verifyJWT, FeatureController.createFeature);
+routes.patch('/feature/desactive/:id', verifyJWT, FeatureController.desactiveFeature);
 routes.delete(
   '/feature/delete/:id',
   verifyJWT,

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -675,6 +675,20 @@ describe('Sample Test', () => {
     done();
   });
 
+  it('desactive feature', async (done) => {
+    const res = await request(app).patch(`/feature/desactive/${featureID}`).set('x-access-token', token);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.active).toBe(false);
+    done();
+  });
+
+  it('desactive feature with invalid id', async (done) => {
+    const res = await request(app).patch(`/feature/desactive/invalidId`).set('x-access-token', token);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ "message": "Invalid ID" });
+    done();
+  });
+
   it('delete feature', async (done) => {
     const res = await request(app).delete(`/feature/delete/${featureID}`).set('x-access-token', token);
     expect(res.statusCode).toBe(200);


### PR DESCRIPTION
Resolve a issue [#4 - Desativação de características](https://github.com/DITGO/2021-2-SiGeD-Doc/issues/4)

<!-- OBSERVAÇÕES:
  - X é o número da issue
  - Só utilize o resolves se o PR fechar a issue por completo
-->

## Descrição

- Adição de campo `active` na model Feature
- Modificação no endpoint `/features/` para trazer apenas características ativas
- Criação de endpoint `/feature/desactive/:id` para desativar característica

## Observação

- Devido a adição de novo campo na model Feature será necessário realizar um update no banco em produção, visando setar o novo campo com valor = `true`, já que as características já existentes no banco estarão com o campo `active` nulo.
- Exemplo dos comandos a serem usados no banco:
`use clients_database`
`db.features.updateMany({active: null }, { $set: { active: true } })`