### PR TITLE
Conserta retorno de características para clientes

### DIFF
--- a/src/Controllers/FeatureController.js
+++ b/src/Controllers/FeatureController.js
@@ -13,7 +13,7 @@ const getFeaturesList = async (req, res) => {
 const getFeaturesByID = async (req, res) => {
   const { featuresList } = req.body;
   try {
-    const features = await Feature.find({ _id: { $in: featuresList }, active: true });
+    const features = await Feature.find({ _id: { $in: featuresList } });
     return res.status(200).json(features);
   } catch (err) {
     return res.status(400).json({ message: 'Invalid ID' });


### PR DESCRIPTION
<!-- OBSERVAÇÕES:
  - X é o número da issue
  - Só utilize o resolves se o PR fechar a issue por completo
-->

## Descrição

Foi retirado o filtro de caracteristicas ativas do endpoint getFeaturesByID que estava afetando histórico do cliente